### PR TITLE
Reduce eval time by switching to gitignore.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,12 @@
 { pkgs ? import ./nix }:
 let
-  src = pkgs.nix-gitignore.gitignoreSource [ "*.nix" ".github" ] ./.;
+  src = pkgs.lib.cleanSourceWith {
+    filter = (name: type:
+      ! (type == "file" && pkgs.lib.hasSuffix ".nix" name)
+      && !(type == "directory" && name == ".github")
+    );
+    src = pkgs.gitignore-nix.gitignoreSource ./.;
+  };
   pkg = pkgs.poetry2nix.mkPoetryApplication {
     inherit src;
     projectDir = ./.;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,6 +5,8 @@ let
       nix-pre-commit-hooks = import (sources.nix-pre-commit-hooks);
 
       poetry2nix = self.callPackage (sources.poetry2nix) { };
+
+      gitignore-nix = self.callPackage (sources."gitignore.nix") { };
     })
   ];
 in

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,16 @@
 {
+    "gitignore.nix": {
+        "branch": "master",
+        "description": "Nix function for filtering local git sources",
+        "homepage": "",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "c4662e662462e7bf3c2a968483478a665d00e717",
+        "sha256": "1npnx0h6bd0d7ql93ka7azhj40zgjp815fw2r6smg8ch9p7mzdlx",
+        "type": "tarball",
+        "url": "https://github.com/hercules-ci/gitignore.nix/archive/c4662e662462e7bf3c2a968483478a665d00e717.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "nix-pre-commit-hooks": {
         "branch": "master",
         "description": "Seamless integration of https://pre-commit.com git hooks with Nix.",


### PR DESCRIPTION
The nix-gitignore implementation in Nixpkgs is very inefficient. It did
dominate our eval times. Almost all of the 23s (on my machine) to
instantiate the default.nix of this project could be attributed it.
After switching to the hercules-ci variant of the same (which is also
composable) the eval time is at around ~3s on my machine. Which is not
ideal but already a HUGE performance improvement. This is especially
important as with .envrc I am evaluating every time I'm dropping into
the shell.